### PR TITLE
"uniq" doesn't work on unsorted input

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > Use this when upgrading version of Go or finding old modules.
 
 ```bash
-$ go list -deps -json ./... | jq -rc 'select(.Standard!="true") | [.Module.Path,.Module.GoVersion] | join(" ")' | grep -v "^ $" | uniq | sort -k 2
+$ go list -deps -json ./... | jq -rc 'select(.Standard!="true") | [.Module.Path,.Module.GoVersion] | join(" ")' | grep -v "^ $" | sort -u -k 2
 go.uber.org/atomic 1.13
 go.uber.org/multierr 1.14
 github.com/nikolaydubina/go-featureprocessing 1.15


### PR DESCRIPTION
Instead of running `uniq` before the sort, use sort's `-u` flag. Otherwise I got multiple identical lines.