### PR TITLE
Tweak simple web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,11 +465,12 @@ Create file like this
 package main
 
 import (
+    "log"
     "net/http"
 )
 
 func main() {
-    http.ListenAndServe(":9000", http.FileServer(http.Dir(".")))
+    log.Fatal(http.ListenAndServe(":9000", http.FileServer(http.Dir("."))))
 }
 ```
 


### PR DESCRIPTION
By wrapping the call to `http.ListenAndServe()` in a `log.Fatal()`, the user will get feedback of the failure. This is useful in case the port is already in use, for example. Otherwise, it fails silently, and that can be confusing/misleading.

My 2¢, and heartfelt congrats for this repo!