### PR TITLE
change oapi-codegen url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1937,7 +1937,7 @@ Requirements
 go install github.com/fatih/gomodifytags@latest
 ```
 
-### [⏫](#contents) :fire: Generate code from OpenAPI 3 specification with [oapi-codegen](https://github.com/deepmap/oapi-codegen)
+### [⏫](#contents) :fire: Generate code from OpenAPI 3 specification with [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen)
 
 Generate Go client and server boilerplate from OpenAPI 3 specifications. — [@deepmap](https://github.com/deepmap)
 
@@ -1948,7 +1948,7 @@ oapi-codegen --config=config.yaml api.yaml
 
 Requirements
 ```
-go install github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@latest
+go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
 ```
 
 ### [⏫](#contents) :fire: Generate C-Go Bindings with [c-for-go](https://github.com/xlab/c-for-go?tab=readme-ov-file)

--- a/page.yaml
+++ b/page.yaml
@@ -1202,11 +1202,11 @@ groups:
         description: "Generate Go client and server boilerplate from OpenAPI 3 specifications."
         name: oapi-codegen
         author: https://github.com/deepmap
-        url: https://github.com/deepmap/oapi-codegen
+        url: https://github.com/oapi-codegen/oapi-codegen
         commands:
           - oapi-codegen --config=config.yaml api.yaml
         requirements:
-          - go install github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@latest
+          - go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
       - title: ":fire: Generate C-Go Bindings"
         description: "This project allows to reuse existing C/C++ libraries in your Go applications, by automatically creating c-go bindings for a given set of C headers and the manifest file. We believe in component-based software engineering and think that reusing C/C++ code in Go applications could bring a huge boost to developer's productivity and system's performance. Read more about the motivation: top reasons to use bindings."
         name: c-for-go


### PR DESCRIPTION
https://github.com/oapi-codegen/oapi-codegen has been migrated to a new repo.