### PR TITLE
update go-mutesting to active maintained fork

### DIFF
--- a/page.yaml
+++ b/page.yaml
@@ -345,6 +345,25 @@ groups:
           - go test -v -tags=mutation
         example_image_url: https://github.com/gtramontina/ooze/blob/main/.assets/report.png
       - title: "Perform Mutation Testing"
+        description: This is fork of [zimmski/go-mutesting](https://github.com/zimmski/go-mutesting). It has more mutators and latest updates.
+        name: "avito-tech/go-mutesting"
+        url: https://github.com/avito-tech/go-mutesting
+        author: https://github.com/vasiliyyudin
+        requirements:
+          - go install github.com/avito-tech/go-mutesting/cmd/go-mutesting@latest
+        commands:
+          - go-mutesting ./...
+        example_content_ext: go
+        example_content: |
+          for _, d := range opts.Mutator.DisableMutators {
+            pattern := strings.HasSuffix(d, "*")
+
+          -	if (pattern && strings.HasPrefix(name, d[:len(d)-2])) || (!pattern && name == d) {
+          +	if (pattern && strings.HasPrefix(name, d[:len(d)-2])) || false {
+              continue MUTATOR
+            }
+          }
+      - title: ":gift: Perform Mutation Testing"
         description: Mutation testing for Go with CI quality gates (`--min-msi`, `--min-covered-msi`), coverage-aware MSI, baseline tracking, git-diff filtering, and structured JSON/HTML reports.
         name: "jonbaldie/go-mutesting"
         url: https://github.com/jonbaldie/go-mutesting

--- a/page.yaml
+++ b/page.yaml
@@ -364,7 +364,7 @@ groups:
             }
           }
       - title: ":gift: Perform Mutation Testing"
-        description: Actively maintained fork of avito-tech/go-mutesting with CI quality gates, covered MSI %, baseline tracking, per-test filtering, parallel execution, and LLM-ready output.
+        description: Fork of avito-tech/go-mutesting with a much richer mutator set, CI quality gates, covered MSI %, baseline tracking, per-test filtering, parallel execution, and LLM-ready output.
         name: "jonbaldie/go-mutesting"
         url: https://github.com/jonbaldie/go-mutesting
         author: https://github.com/jonbaldie

--- a/page.yaml
+++ b/page.yaml
@@ -363,25 +363,6 @@ groups:
               continue MUTATOR
             }
           }
-      - title: "Perform Mutation Testing"
-        description: Find common bugs source code that would pass tests. This is earliest tool for mutation testing in Go. More functions and permutations were added in other mutation Go tools it inspired.
-        name: go-mutesting
-        url: https://github.com/zimmski/go-mutesting
-        author: https://github.com/zimmski
-        requirements:
-          - go install github.com/zimmski/go-mutesting/cmd/go-mutesting@latest
-        commands:
-          - go-mutesting ./...
-        example_content_ext: go
-        example_content: |
-          for _, d := range opts.Mutator.DisableMutators {
-            pattern := strings.HasSuffix(d, "*")
-
-          -	if (pattern && strings.HasPrefix(name, d[:len(d)-2])) || (!pattern && name == d) {
-          +	if (pattern && strings.HasPrefix(name, d[:len(d)-2])) || false {
-              continue MUTATOR
-            }
-          }
       - title: "Trace tests"
         description: Collect test execution as distributed traces. This is useful for tracking test duration, failures, and flakiness. Your distributed tracing storage, search, UI, exploration, dashboards, and alarms all automatically become test status collection. If you run integration tests in your CI, then it is particularly handy to investigate your integration tests the same way as real requests, such as Go processes, databases, etc. However, if you do not have distributed traces, it is still useful for ad hoc investigations. This tool processes STDOUT of `go test`. No automatic instrumentation is done.
         name: go-test-trace

--- a/page.yaml
+++ b/page.yaml
@@ -345,7 +345,7 @@ groups:
           - go test -v -tags=mutation
         example_image_url: https://github.com/gtramontina/ooze/blob/main/.assets/report.png
       - title: "Perform Mutation Testing"
-        description: Actively maintained fork of zimmski/go-mutesting with CI quality gates (`--min-msi`, `--min-covered-msi`), coverage-aware MSI, baseline tracking, git-diff filtering, and structured JSON/HTML reports.
+        description: Mutation testing for Go with CI quality gates (`--min-msi`, `--min-covered-msi`), coverage-aware MSI, baseline tracking, git-diff filtering, and structured JSON/HTML reports.
         name: "jonbaldie/go-mutesting"
         url: https://github.com/jonbaldie/go-mutesting
         author: https://github.com/jonbaldie

--- a/page.yaml
+++ b/page.yaml
@@ -364,7 +364,7 @@ groups:
             }
           }
       - title: ":gift: Perform Mutation Testing"
-        description: Mutation testing for Go with CI quality gates (`--min-msi`, `--min-covered-msi`), coverage-aware MSI, baseline tracking, git-diff filtering, and structured JSON/HTML reports.
+        description: Actively maintained fork of avito-tech/go-mutesting with CI quality gates, covered MSI %, baseline tracking, per-test filtering, parallel execution, and LLM-ready output.
         name: "jonbaldie/go-mutesting"
         url: https://github.com/jonbaldie/go-mutesting
         author: https://github.com/jonbaldie

--- a/page.yaml
+++ b/page.yaml
@@ -345,12 +345,12 @@ groups:
           - go test -v -tags=mutation
         example_image_url: https://github.com/gtramontina/ooze/blob/main/.assets/report.png
       - title: "Perform Mutation Testing"
-        description: This is fork of [zimmski/go-mutesting](https://github.com/zimmski/go-mutesting). It has more mutators and latest updates.
-        name: "avito-tech/go-mutesting"
-        url: https://github.com/avito-tech/go-mutesting
-        author: https://github.com/vasiliyyudin
+        description: Actively maintained fork of zimmski/go-mutesting with CI quality gates (`--min-msi`, `--min-covered-msi`), coverage-aware MSI, baseline tracking, git-diff filtering, and structured JSON/HTML reports.
+        name: "jonbaldie/go-mutesting"
+        url: https://github.com/jonbaldie/go-mutesting
+        author: https://github.com/jonbaldie
         requirements:
-          - go install github.com/avito-tech/go-mutesting/cmd/go-mutesting@latest
+          - go install github.com/jonbaldie/go-mutesting/v2/cmd/go-mutesting@latest
         commands:
           - go-mutesting ./...
         example_content_ext: go


### PR DESCRIPTION
The go-mutesting tool has evolved through three repos: zimmski/go-mutesting (original, last commit June 2021), avito-tech/go-mutesting (fork with more mutators, last commit December 2025), and now [jonbaldie/go-mutesting](https://github.com/jonbaldie/go-mutesting), which is the most featureful current version. This PR updates the avito-tech entry to point to jonbaldie and removes the original zimmski entry — only one entry is needed and it should point to the tool with the most active development.

[jonbaldie/go-mutesting](https://github.com/jonbaldie/go-mutesting) feature set:

- CI quality gates (`--min-msi`, `--min-covered-msi`) — fail the build below a mutation score threshold
- Coverage-aware MSI — scores covered and uncovered mutations separately
- Baseline file — tracks known-surviving mutants so CI only fails on *new* regressions
- Git-diff filtering (`--git-diff-lines`) — only mutates lines changed in a PR
- Parallel execution with `--workers`
- Per-test coverage map (`--per-test`) — runs only tests that cover each mutant
- Structured JSON, HTML, and LLM-ready agentic reports
- GitHub Actions annotation output
- Active release cadence with semver tags
- Documentation site: https://jonbaldie.github.io/go-mutesting/

It was accepted onto [avelino/awesome-go](https://github.com/avelino/awesome-go/pull/6333) this week on the same basis.
