### PR TITLE
ci: check Markdown links

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -1,0 +1,23 @@
+name: Markdown links
+
+on:
+  push:
+    branches: [master]
+    paths: ["**/*.md"]
+  pull_request:
+    paths: ["**/*.md"]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2.9.0
+        with:
+          args: --no-progress "**/*.md"


### PR DESCRIPTION
## Summary

Add automated Markdown link checking with Lychee.

- Run on pull requests and pushes that change Markdown.
- Run weekly to detect external link rot even when documentation is unchanged.
- Allow manual runs for maintenance.
- Keep workflow permissions read-only and pin the action to a released version.

Closes #260

## Validation

- Workflow YAML parsed successfully.
- `actionlint` passed for `.github/workflows/markdown-links.yml`.
- The first pull-request run will validate the repository’s current 444 unique Markdown URLs with Lychee.